### PR TITLE
feat: Add 17mov_CharacterSystem Wardrobe

### DIFF
--- a/settings.lua
+++ b/settings.lua
@@ -103,6 +103,7 @@ Resources = {
     QBClothing = { name = 'qb-clothing', export = false },
     ESXSKIN = { name = 'esx_skin', export = false },
     CRM = { name = 'crm-appearance', export = false },
+    MOVCS = { name = '17mov_CharacterSystem', export = false },
 
     -- MOVHUD = { name = '17mov_Hud', export = 'all' },
 }

--- a/wrappers/client/player.lua
+++ b/wrappers/client/player.lua
@@ -75,6 +75,8 @@ function FM.player.openWardrobe(propertyId)
         TriggerEvent('esx_skin:openSaveableMenu')
     elseif CRM then
         TriggerEvent('crm-appearance:show-outfits')
+    elseif MOVCS then
+        TriggerEvent("17mov_CharacterSystem:OpenOutfitsMenu")
     else
         FM.console.err("No wardrobe resource found")
     end


### PR DESCRIPTION
Adds missing wardrobe support for 17mov_CharacterSystem.

Some servers use 17mov_CharacterSystem as their main appearance/wardrobe script. This PR registers the resource in settings.lua and adds the corresponding event call in FM.player.openWardrobe, so the wardrobe opens correctly when MOVCS is present.