### PR TITLE
Add OKOK/TI/X fuel adapters

### DIFF
--- a/adapters/client/fuel/okokGasStation.lua
+++ b/adapters/client/fuel/okokGasStation.lua
@@ -1,0 +1,19 @@
+--[[
+    fmLib - OKOKGasStation Fuel Adapter
+]]
+
+local adapter = {}
+local resourceName  -- Store the resource name
+
+function adapter.init(resource)
+    resourceName = resource
+end
+
+function adapter.set(vehicle, fuelLvl)
+    if not vehicle or fuelLvl == nil then return end
+
+    fuelLvl = fuelLvl + 0.0
+    exports[resourceName]:SetFuel(vehicle, fuelLvl)
+end
+
+FM_Adapter_client_fuel_okok = adapter

--- a/adapters/client/fuel/ti_fuel.lua
+++ b/adapters/client/fuel/ti_fuel.lua
@@ -1,0 +1,19 @@
+--[[
+    fmLib - TI Fuel Adapter
+]]
+
+local adapter = {}
+local resourceName  -- Store the resource name
+
+function adapter.init(resource)
+    resourceName = resource
+end
+
+function adapter.set(vehicle, fuelLvl)
+    if not vehicle or fuelLvl == nil then return end
+
+    fuelLvl = fuelLvl + 0.0
+    exports[resourceName]:SetFuel(vehicle, fuelLvl)
+end
+
+FM_Adapter_client_fuel_ti = adapter

--- a/adapters/client/fuel/x-fuel.lua
+++ b/adapters/client/fuel/x-fuel.lua
@@ -1,0 +1,19 @@
+--[[
+    fmLib - X Fuel Adapter
+]]
+
+local adapter = {}
+local resourceName  -- Store the resource name
+
+function adapter.init(resource)
+    resourceName = resource
+end
+
+function adapter.set(vehicle, fuelLvl)
+    if not vehicle or fuelLvl == nil then return end
+
+    fuelLvl = fuelLvl + 0.0
+    exports[resourceName]:SetFuel(vehicle, fuelLvl)
+end
+
+FM_Adapter_client_fuel_x = adapter

--- a/settings.lua
+++ b/settings.lua
@@ -99,6 +99,9 @@ AdapterResources = {
         { key = 'lj',       resource = 'lj-fuel' },
         { key = 'melons',   resource = 'melons_fuel' },
         { key = 'hrs',      resource = 'hrs_fuel' },
+        { key = 'okok',    resource = 'okokFuel' },
+        { key = 'ti',      resource = 'ti_fuel' },
+        { key = 'x',    resource = 'x-fuel' },
     },
 
     textui = {


### PR DESCRIPTION
Introduce three new client fuel adapters (okokGasStation, ti_fuel, x-fuel) that expose a simple init(resource) and set(vehicle, fuelLvl) API. Each adapter stores the resource name and calls exports[resource]:SetFuel(vehicle, fuelLvl) after basic nil checks. Also register the new adapters in AdapterResources in settings.lua (keys: okok, ti, x) so they can be selected/used by the framework.